### PR TITLE
Fix json-rpc version string

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -8,7 +8,7 @@ export type RPCIniOptions = RESTIniOptions & {
 };
 
 export type JSONRPC = {
-  jsonrpc?: string | number;
+  jsonrpc?: string;
   id?: string | number;
   method: string;
   params?: object;
@@ -410,7 +410,7 @@ export class RPCClient extends RESTClient {
 
   async rpc(method: string, params = {}, wallet?: string) {
     const uri = typeof wallet === "undefined" ? "/" : "wallet/" + wallet;
-    const body = { method, params, jsonrpc: 1.0, id: "rpc-bitcoin" };
+    const body = { method, params, jsonrpc: "1.0", id: "rpc-bitcoin" };
     try {
       const response = await this.batch(body, uri);
       return this.fullResponse ? response : response.result;


### PR DESCRIPTION
After running into issues while testing [public-pool](https://github.com/benjamin-wilson/public-pool) using the latest main commit of bitcoin-core, I finally found that the root cause of my pain was the json-rpc version field which is used by this library.

According to [json-rpc spec](https://www.jsonrpc.org/specification), the json-rpc version HAS to be a string. But here it's created as a number, in the body used for rpc request: https://github.com/vansergen/rpc-bitcoin/blob/ace0f6889d2454c741600bd2a85de410ca494f1d/src/rpc.ts#L413

This leads to an error from bitcoin-core, since in [this PR](https://github.com/bitcoin/bitcoin/pull/27101/files) that has been merged a check was introduced. The line where the error is generated is here: https://github.com/bitcoin/bitcoin/blob/ff7d2054c4f1d7ff98078b9695e7c36e79a476c6/src/rpc/request.cpp#L197

This PR fixes this incompatibility, by using a string instead of a number there.